### PR TITLE
Add templates as public methods to the notify widget

### DIFF
--- a/src/jquery.notify.js
+++ b/src/jquery.notify.js
@@ -31,6 +31,11 @@
         var key = this.id || i;
         self.keys.push(key);
         self.templates[key] = $(this).removeAttr("id").wrap("<div></div>").parent().html(); // because $(this).andSelf().html() no workie
+        
+        // Add templates as public methods to this widget
+        if ( !self[key] ) {
+            self[key] = $.proxy( self.create, self, key );
+        }
       }).end().empty().show();
     },
 


### PR DESCRIPTION
A simple enhancement to allow notification template names act as public methods to notification widget instances.

This opens up nice api feature whereby one can define templates with names like "message", "error", etc and then call notifications widget like this:

$notify = $( "#container" ).notify();
$notify.notify("error", {title: "Error", text:"Bad bad error from somewhere"}, ...);
$notify.notify("message", {title: "Hurray", text:"Good. You've made it!"}, ...);
